### PR TITLE
Fix GUI dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ source venv/bin/activate # activate virtual env
 # install LogAI and GUI dependencies
 pip install ".[dev]"
 pip install ".[gui]"
+pip install ".[deep-learning]"
 
 # Start LogAI service
 export PYTHONPATH='.'  # make sure to add current root to PYTHONPATH


### PR DESCRIPTION
Need to install `.[deep-learning]` for running `python3 gui/application.py`. Otherwise, I get errors like `ModuleNotFoundError: No module named 'torch'` for missing torch, datasets. etc.