### PR TITLE
Update requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,9 @@
 GitPython
 beautifulsoup4
 ipykernel
-nbsphinx
 pandoc
-sphinx
+sphinx==6.2.1
+nbsphinx
 sphinx_autodoc_typehints
 sphinx_rtd_theme
 recommonmark


### PR DESCRIPTION
Pin sphinx to 6.2.1 due to incompatibility issue with handling of `styles`.  See (salesforce/logai issue 59)[https://github.com/salesforce/logai/issues/59]